### PR TITLE
Adjust cache times

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -47,9 +47,6 @@ sub vcl_fetch {
 
   esi;
 
-  # cache everything for 8 hours ignoring any cache headers
-  set beresp.ttl = 8h;
-
   # use stale for a lot longer in case of fail, or our internet is down
   set beresp.stale_if_error = 168h;
 }

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -51,7 +51,7 @@ sub vcl_fetch {
   set beresp.ttl = 8h;
 
   # use stale for a lot longer in case of fail, or our internet is down
-  set beresp.stale_if_error = 48h;
+  set beresp.stale_if_error = 168h;
 }
 
 sub vcl_recv {


### PR DESCRIPTION
The cache time from `polyfill.io` is 1 week. Let's respect that time instead of setting our own.

Also, we explicitly set the `stale_if_error` to 1 week in case there is a problem with the polyfill backend.

@rich-nguyen @regiskuckaertz 